### PR TITLE
Badge (unread/mention counts) support with IPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRC = src/main.js src/menu.js src/index.html src/package.json src/config.json
+SRC = src/main.js src/menu.js src/index.html src/load-src.js src/webview.js src/package.json src/config.json
 RES = resources/*
 
 all: dist

--- a/src/index.html
+++ b/src/index.html
@@ -81,7 +81,7 @@
   </script>
   </head>
   <body>
-    <webview id='mattermost-remote' src partition='persist:mattermost'></webview>
+    <webview id='mattermost-remote' src partition='persist:mattermost' preload="webview.js"></webview>
     <div id='overlay'></div>
   </body>
 </html>

--- a/src/load-src.js
+++ b/src/load-src.js
@@ -1,5 +1,49 @@
+var remote = require('remote');
+var app = remote.require('app');
+
 document.addEventListener('DOMContentLoaded', function() {
-    var qs = window.location.search
+    var qs = window.location.search;
     var src = decodeURIComponent(qs.replace('?', '').split('&')[0].split('=')[1]);
-    document.querySelector('#mattermost-remote').setAttribute('src', src);
+    var webview = document.querySelector('#mattermost-remote');
+
+    webview.setAttribute('src', src);
+
+    var badgeUpdateTimer = setInterval(function() {
+        webview.send('unread-count');
+        webview.send('mention-count');
+    }, 1000);
+
+    var unreadCount = 0;
+    var mentionCount = 0;
+
+    webview.addEventListener('ipc-message', function(event) {
+        switch (event.channel) {
+            case 'unread-count':
+                unreadCount = event.args[0];
+                break;
+            case 'mention-count':
+                mentionCount = event.args[0];
+                break;
+        }
+
+        badgeUpdate(unreadCount, mentionCount);
+    });
+
+    var badgeUpdate = function(unreadCount, mentionCount) {
+        var newBadge = false;
+        if (unreadCount > 0) {
+            newBadge = '●';
+        } else if (unreadCount == 0) {
+            newBadge = '';
+        }
+
+        if (mentionCount > 0) {
+            newBadge = mentionCount;
+            app.dock.bounce('critical');
+        }
+
+        if (newBadge !== false) {
+            app.dock.setBadge(newBadge.toString());
+        }
+    };
 });

--- a/src/webview.js
+++ b/src/webview.js
@@ -1,0 +1,11 @@
+var ipc = require('ipc');
+
+ipc.on('unread-count', function() {
+    var unreadCount = $('.unread-title').length;
+    ipc.sendToHost('unread-count', unreadCount);
+});
+
+ipc.on('mention-count', function() {
+    var mentionCount = $('.unread-title .badge').length;
+    ipc.sendToHost('mention-count', mentionCount);
+});


### PR DESCRIPTION
Add support for badge notification similar to Slack.  Unread activity will be displayed as a badge with a dot, while mentions will be displayed as a number in the badge.
