### PR TITLE
Rewrite the badge notification without a timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /config.json
 /src/config.json
 .tag*
+.idea

--- a/src/load-src.js
+++ b/src/load-src.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var remote = require('remote');
 var app = remote.require('app');
 
@@ -8,28 +10,36 @@ document.addEventListener('DOMContentLoaded', function() {
 
     webview.setAttribute('src', src);
 
-    var badgeUpdateTimer = setInterval(function() {
-        webview.send('unread-count');
-        webview.send('mention-count');
-    }, 1000);
-
     var unreadCount = 0;
     var mentionCount = 0;
+    var bounceId = null;
+    var pendingUpdate = null;
 
     webview.addEventListener('ipc-message', function(event) {
         switch (event.channel) {
             case 'unread-count':
-                unreadCount = event.args[0];
+                unreadCount = parseInt(event.args[0], 10);
                 break;
             case 'mention-count':
-                mentionCount = event.args[0];
+                mentionCount = parseInt(event.args[0], 10);
                 break;
         }
 
-        badgeUpdate(unreadCount, mentionCount);
+        // if we send too many badgeUpdates, the app instantiated from the remote seems to use a
+        // LIFO queue so we end up overwriting the most recent one update with an older one
+        // so instead we'll wait 500ms and then if the timeout is not cancelled we'll update for real
+        if (pendingUpdate) {
+            clearTimeout(pendingUpdate);
+        }
+
+        pendingUpdate = setTimeout(badgeUpdate, 500);
     });
 
-    var badgeUpdate = function(unreadCount, mentionCount) {
+    webview.addEventListener('console-message', function(event) {
+        console.log('Mattermost: ', event.message);
+    });
+
+    var badgeUpdate = function() {
         var newBadge = false;
         if (unreadCount > 0) {
             newBadge = '●';
@@ -39,11 +49,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
         if (mentionCount > 0) {
             newBadge = mentionCount;
-            app.dock.bounce('critical');
+            if (bounceId) app.dock.cancelBounce(bounceId);
+            bounceId = app.dock.bounce('critical');
+        } else if (mentionCount == 0) {
+            if (bounceId) app.dock.cancelBounce(bounceId);
         }
 
         if (newBadge !== false) {
             app.dock.setBadge(newBadge.toString());
         }
+
+        pendingUpdate = null;
     };
 });

--- a/src/webview.js
+++ b/src/webview.js
@@ -41,9 +41,9 @@ document.addEventListener("DOMContentLoaded", function() {
     var list = document.querySelector('.ps-container');
 
     var observer = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation) {
+        if (mutations.length) {
             checkActivity();
-        });
+        }
     });
 
     if (list) {

--- a/src/webview.js
+++ b/src/webview.js
@@ -35,10 +35,24 @@ var checkActivity = function() {
 };
 
 document.addEventListener("DOMContentLoaded", function() {
-    // hook into the DOM to detect changes and count the mentions and unread activity
-    $(document).bind("DOMSubtreeModified", function() {
-        checkActivity();
+    // observe the DOM for mutations, specifically the .ps-container
+    // which contains all the sidebar channels
+    var MutationObserver = window.MutationObserver;
+    var list = document.querySelector('.ps-container');
+
+    var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+            checkActivity();
+        });
     });
+
+    if (list) {
+        observer.observe(list, {
+            subtree: true,
+            attributes: true,
+            childList: true
+        });
+    }
 
     // initial one time notification
     checkActivity();

--- a/src/webview.js
+++ b/src/webview.js
@@ -1,11 +1,45 @@
+"use strict";
+
 var ipc = require('ipc');
 
-ipc.on('unread-count', function() {
-    var unreadCount = $('.unread-title').length;
-    ipc.sendToHost('unread-count', unreadCount);
-});
+var mentionCount = 0;
+var unreadCount = 0;
 
-ipc.on('mention-count', function() {
-    var mentionCount = $('.unread-title .badge').length;
+var notifyHost = function() {
+    // send back the counts to the webview host
     ipc.sendToHost('mention-count', mentionCount);
+    ipc.sendToHost('unread-count', unreadCount);
+};
+
+// we'll only notify if there's a change in the counts
+var checkActivity = function() {
+    let notify = false;
+    let localMentionCount = 0;
+    // get the actual count of mentions from Mattermost
+    $('.unread-title.has-badge .badge').each(function() { localMentionCount += parseInt($(this).text(), 10); });
+
+    // set flag to notify if the mention count has changed
+    if (localMentionCount != mentionCount) {
+        mentionCount = localMentionCount;
+        notify = true;
+    }
+
+    let localUnreadCount = $('.unread-title').length;
+    // set flag to notify if the unread count has changed
+    if (localUnreadCount != unreadCount) {
+        unreadCount = localUnreadCount;
+        notify = true;
+    }
+
+    if (notify) notifyHost();
+};
+
+document.addEventListener("DOMContentLoaded", function() {
+    // hook into the DOM to detect changes and count the mentions and unread activity
+    $(document).bind("DOMSubtreeModified", function() {
+        checkActivity();
+    });
+
+    // initial one time notification
+    checkActivity();
 });


### PR DESCRIPTION
To avoid using a timer, the preloaded JS will now be hooking into the `DOMSubtreeModified` event.

Also added some comments, cleaned up some of the code and made it so the notifications should only be sent if there is a change in the count.
