### PR TITLE
Add 32-bit windows to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,23 @@ dist/Matterfront-win32-x64/Matterfront.exe: $(SRC) $(RES)
 	mkdir -p dist
 	node_modules/.bin/electron-packager src Matterfront --platform=win32 --arch=x64 --version=0.34.2 --out=dist --icon=resources/mattermost --app-version=0.1.0 --asar --overwrite
 
+dist/Matterfront-win32-ia32/Matterfront.exe: $(SRC) $(RES)
+	mkdir -p dist
+	node_modules/.bin/electron-packager src Matterfront --platform=win32 --arch=ia32 --version=0.34.2 --out=dist --icon=resources/mattermost --app-version=0.1.0 --asar --overwrite
+
 dist/Matterfront-linux-x64/Matterfront: $(SRC) $(RES)
 	mkdir -p dist
 	node_modules/.bin/electron-packager src Matterfront --platform=linux --arch=x64 --version=0.34.2 --out=dist --icon=resources/mattermost --app-version=0.1.0 --asar --overwrite
 
-dist: electrify dist/Matterfront-darwin-x64/Matterfront.app dist/Matterfront-win32-x64/Matterfront.exe dist/Matterfront-linux-x64/Matterfront
+dist: electrify dist/Matterfront-darwin-x64/Matterfront.app dist/Matterfront-win32-x64/Matterfront.exe dist/Matterfront-win32-ia32/Matterfront.exe dist/Matterfront-linux-x64/Matterfront
 
 dist/Matterfront-darwin-x64.zip: dist/Matterfront-darwin-x64
 	cd $(dir $@); zip -r $(notdir $@) $(notdir $^)
 
 dist/Matterfront-win32-x64.zip: dist/Matterfront-win32-x64
+	cd $(dir $@); zip -r $(notdir $@) $(notdir $^)
+
+dist/Matterfront-win32-ia32.zip: dist/Matterfront-win32-ia32
 	cd $(dir $@); zip -r $(notdir $@) $(notdir $^)
 
 dist/Matterfront-linux-x64.zip: dist/Matterfront-linux-x64


### PR DESCRIPTION
I was gonna test the badge code for Windows but apparently the VM I grabbed was 32-bit and then I realized the Makefile did not have build commands for 32-bit.
