### PR TITLE
Builds use the Mattermost icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An application for [Mattermost](http://mattermost.org) for OS X, Windows, and Li
 First, clone down this project, and then from within that directory in your favorite terminal run:
 
 ```
->  npm install 
+>  npm install
 // installs packages....
 > npm link
 // creates a local symlink
@@ -40,11 +40,11 @@ a locally hostable mattermost instance you can use for testing. Alternatively, y
 
 ### Use your production Mattermost instance
 
-After following the configuration steps above, run `npm start` from within your matterfront directory 
+After following the configuration steps above, run `npm start` from within your matterfront directory
 
 ### Vagrant method
 
-1. Set up your `config.json` using `"url":"http://192.168.33.33"` 
+1. Set up your `config.json` using `"url":"http://192.168.33.33"`
 2. run `vagrant up` from within your local
 copy of this repo
 3. run `npm start`
@@ -67,9 +67,11 @@ dist/
  |- matterfront-win32-x64/
 ```
 
-Each directory contains an executable for the platform listed. For more detailed 
+Each directory contains an executable for the platform listed. For more detailed
 build options, check out how to modify your `build` from within `package.json` by
 using the options from [electron-packager](https://github.com/maxogden/electron-packager#usage) to modify your built artifacts.
+
+If you are on Linux or OS X, you need Wine [for Windows builds](https://github.com/maxogden/electron-packager#building-windows-apps-from-non-windows-platforms).
 
 ## Name and affiliation
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "start": "electron ./src",
-    "build": "electron-packager ./src matterfront --out=dist --ignore='^/dist$' --prune --asar --platform=all --arch=all --version=$npm_package_electronVersion --app-bundle-id='org.matterfront.app' --app-version=$npm_package_version --helper-bundle-id='org.matterfront.app.helper' --overwrite"
+    "build": "electron-packager ./src matterfront --out=dist --ignore='^/dist$' --prune --asar --platform=all --arch=all --version=$npm_package_electronVersion --app-bundle-id='org.matterfront.app' --app-version=$npm_package_version --helper-bundle-id='org.matterfront.app.helper' --overwrite --icon resources/mattermost"
   },
   "electronVersion": "0.34.3",
   "repository": {


### PR DESCRIPTION
In #19, @H3Chief wrote that using `--icon` causes a build failure for the darwin platform. Is this still the case? I'm on OS X and `npm run build' runs fine for me.
