### PR TITLE
Keep the focus on the webview when switching apps.

### DIFF
--- a/src/load-src.js
+++ b/src/load-src.js
@@ -41,6 +41,12 @@ document.addEventListener('DOMContentLoaded', function() {
         console.log('Mattermost: ', event.message);
     });
 
+    // Keep the focus on the webview.
+    // Without this, the webview loses focus when switching to another app and back.
+    window.addEventListener('focus', function(e) {
+      webview.focus();
+    });
+
     var badgeUpdate = function() {
         var newBadge = false;
         if (unreadCount > 0) {


### PR DESCRIPTION
When switching from Matterfont to another app and back using Cmd-Tab, the text input currently looses the focus.
