### PR TITLE
Load the menu when the app is ready instead of including it in the HTML file

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,6 @@
     // force load electron
     process.versions['electron']
   </script>
-  <script src='menu.js'></script>
   <script src='load-src.js'></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/src/main.js
+++ b/src/main.js
@@ -74,4 +74,6 @@ app.on('ready', function() {
   mainWindow.on('closed', function() {
     mainWindow = null;
   });
+
+  require('./menu.js');
 });

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,6 +1,5 @@
-var remote = require('remote');
-var app = remote.require('app');
-var Menu = remote.require('menu');
+var app = require('app');
+var Menu = require('menu');
 
 var template = [
   {


### PR DESCRIPTION
This should fix the menu error when reloading the app, see #31.
