### PR TITLE
Allow insecure resources like images to be loaded by Mattermost

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -80,7 +80,7 @@
   </script>
   </head>
   <body>
-    <webview id='mattermost-remote' src partition='persist:mattermost' preload="webview.js"></webview>
+    <webview id='mattermost-remote' src partition='persist:mattermost' preload="webview.js" disablewebsecurity="on"></webview>
     <div id='overlay'></div>
   </body>
 </html>


### PR DESCRIPTION
This "fixes" the mixed content error displayed in the console of the Mattermost instance, issue #39.
