### PR TITLE
fix(dev-mode) improve dev-mode & onboarding:

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run start-watch
 Leave the dev server running, and then start matterfront in dev mode by running:
 
 ```
-npm run start
+npm run start-dev
 ```
 
 Now as you edit your browser-side code, the app should update automatically, without even having to reload the page.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "npm run js && electron-packager . Matterfront --out=dist --ignore='^/dist$' --asar --platform=all --arch=all --version=$npm_package_electronVersion --app-bundle-id='org.matterfront.app' --app-version=$npm_package_version --helper-bundle-id='org.matterfront.app.helper' --overwrite --icon=resources/mattermost",
     "js": "webpack",
     "lint": "eslint ./src --ignore-path .gitignore",
-    "start": "electron .",
+    "start": "webpack; electron .",
+    "start-dev": "electron . --dev-mode",
     "start-watch": "webpack-dev-server --port 9000",
     "test": "mocha",
     "test-watch": "mocha watch"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run js && electron-packager . Matterfront --out=dist --ignore='^/dist$' --asar --platform=all --arch=all --version=$npm_package_electronVersion --app-bundle-id='org.matterfront.app' --app-version=$npm_package_version --helper-bundle-id='org.matterfront.app.helper' --overwrite --icon=resources/mattermost",
     "js": "webpack",
     "lint": "eslint ./src --ignore-path .gitignore",
-    "start": "webpack; electron .",
+    "start": "webpack && electron .",
     "start-dev": "electron . --dev-mode",
     "start-watch": "webpack-dev-server --port 9000",
     "test": "mocha",


### PR DESCRIPTION
- start command now runs webpack before firing up electron to prevent frustration to new contributors
- Added start-dev npm command that fires electron  with --dev-mode flag
- Updated readme to use npm start-dev for dev-mode with webpack
