### PR TITLE
clear cache before force reloading

### DIFF
--- a/src/menu-template.js
+++ b/src/menu-template.js
@@ -40,11 +40,14 @@ var template = [{
       }
     }
   }, {
-    label: 'Hard reload',
+    label: 'Clear cache and reload',
     accelerator: 'CmdOrCtrl+Shift+R',
     click: function(item, focusedWindow) {
       if (focusedWindow){
-        focusedWindow.reload(true);
+        // TODO: works only because partition on webview gets lost
+        focusedWindow.webContents.session.clearCache(function () {
+          focusedWindow.reload(true);
+        });
       }
     }
   }, {

--- a/src/menu-template.js
+++ b/src/menu-template.js
@@ -46,7 +46,7 @@ var template = [{
       if (focusedWindow){
         // TODO: works only because partition on webview gets lost
         focusedWindow.webContents.session.clearCache(function () {
-          focusedWindow.reload(true);
+          focusedWindow.reloadIgnoringCache();
         });
       }
     }


### PR DESCRIPTION
replaces #69 because of future usage of `partition`, for which we need to clear separately and reload after everything has been cleared (hence `reloadIgnoringCache` won't do).
