### PR TITLE
Make team buttons smaller and hide when a single team is configured

### DIFF
--- a/src/browser/team-buttons.jsx
+++ b/src/browser/team-buttons.jsx
@@ -5,8 +5,9 @@ require("./team-buttons.less");
 var TeamButtons = React.createClass({
   render: function(){
     var style = this.calculateStyle();
+    var hideClass = this.hasMultipleTeams() ? "" : "hideTeamButtons";
     return (
-      <div className="teamButtons" style={style}>
+      <div className={"teamButtons " + hideClass} style={style}>
         {this.renderButtons()}
       </div>
     );
@@ -31,6 +32,9 @@ var TeamButtons = React.createClass({
     } else {
       return {};
     }
+  },
+  hasMultipleTeams: function(){
+    return Object.keys(this.props.teams).length > 1;
   }
 });
 

--- a/src/browser/team-buttons.less
+++ b/src/browser/team-buttons.less
@@ -1,23 +1,25 @@
 .teamButtons {
-  font-size: 2em;
+  font-size: 1.6em;
   background-color: #CCCCCC;
   height: 100vh;
-  flex-basis: 3em;
+  flex-basis: 2.7em;
 
   .teamButton {
     display: flex;
     position: relative;
     background-color: white;
     border-radius: 5px;
-    width: 2em;
-    height: 2em;
+    width: 1em;
+    height: 1em;
     margin: .5em;
+    margin-left: 0.6em;
     justify-content: center;
     align-items: center;
     font-family: sans-serif;
     flex-grow: 1;
     cursor: pointer;
     box-sizing: content-box;
+    padding: 0.3em;
 
     .selectionTab {
       position: absolute;
@@ -26,6 +28,7 @@
       width: 20px;
       border-radius: 5px;
       left: -30px;
+      margin-top: -0.3em;
     }
 
     &.selected .selectionTab {

--- a/src/browser/team-buttons.less
+++ b/src/browser/team-buttons.less
@@ -4,6 +4,10 @@
   height: 100vh;
   flex-basis: 2.7em;
 
+  &.hideTeamButtons {
+    display: none;
+  }
+
   .teamButton {
     display: flex;
     position: relative;

--- a/test/browser/team-buttons-spec.js
+++ b/test/browser/team-buttons-spec.js
@@ -1,0 +1,33 @@
+var TeamButtons = require("../../src/browser/team-buttons.jsx");
+
+describe("TeamButtons", function(){
+
+  var state = {
+        connectionState: "online",
+        selectedTeam: "dev",
+        teams: {
+          dev: {
+            mentionCount: 0,
+            name: "dev",
+            themeData: {
+              sidebarBackground: "rgb(47, 129, 183)"
+            },
+            unreadCount: 0,
+            url: "http://matterfront/local-dev"
+          }
+        }
+      };
+
+  it ("adds hide class when it has only one team", function(){
+    var el = $(razz.render(TeamButtons, state)).children().first();
+    expect(el).to.have.$attr("class", "teamButtons hideTeamButtons");
+  });
+
+  it ("does not add hide class when it has multiple teams", function(){
+    var el = $(razz.render(TeamButtons, state)).children().first();
+    expect(el).to.have.$attr("class", "teamButtons hideTeamButtons");
+  });
+
+
+
+});


### PR DESCRIPTION
Not sure if this is something you want or if its done the prefered way, but here it is.

The team buttons seemed unnecessarily large. It becomes more obvious when using it at about a quarter of fullscreen size. At least with my setup.

I tried to make it about the same size as Slack has in its app. I have attached some screenshot to show the difference.

Also hides team buttons sidebar when only one team is configured.

![matterfront-default-teambuttons](https://cloud.githubusercontent.com/assets/185551/12128178/f45a0c86-b3fb-11e5-9c0c-cde6f27ed28e.png)
![matterfron-smaller-teambuttons](https://cloud.githubusercontent.com/assets/185551/12128180/f45b61ee-b3fb-11e5-92c0-5c4d3667cdfb.png)
![matterfront-hide-teambuttons](https://cloud.githubusercontent.com/assets/185551/12128179/f45a6db6-b3fb-11e5-9ae8-29a87aa668bd.png)
